### PR TITLE
[Chore] Add  `socat` Dependency Installation to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,22 @@ Many parts of Playbit are still closed source, though we are committed to openin
 ## Setting up for development
 
 For Playbit 0.7.x and older, you need to connect a terminal from your host machine into Playbit's root system.
-With Playbit running, open a terminal on your host machine and do the following:
+
+To make this connection, `root-vconsole` depends on [`socat`](https://linux.die.net/man/1/socat). Install `socat` on your host machine via your preferred method:
+
+```
+$ brew install socat
+
+$ apt install socat
+
+$ apk add socat
+
+$ pacman -S socat
+
+$ pkg install socat
+```
+
+Then, with Playbit running, open a terminal on your host machine and do the following:
 
 ```
 $ curl -L#O https://github.com/playbit/pb-src/raw/refs/heads/main/tools/root-vconsole


### PR DESCRIPTION
This PR proposes updatin `README.md` to explicitly include instructions for adding `socat` as a dependency when setting up `root-vconsole` for `pb-src` development.

Though a small chore, this change should help to communicate requirements in advance of the setup workflow. Instead of the current developer experience, which interrupts the person running `./root-vconsole` for the first time if `socat` isn't installed, this forewarns them of the install, reducing friction during setup.